### PR TITLE
Change resilient threshold_values picker.

### DIFF
--- a/jobs/newrelic_response.rb
+++ b/jobs/newrelic_response.rb
@@ -28,8 +28,7 @@ last_x = points.last[:x]
 ## Every 1m for this
 SCHEDULER.every '1m', :first_in => 0 do |job|
 
-  ## Reponse time is the fourth value returned by new relic
-  current_response = app_select[0].threshold_values[5].metric_value
+  current_response = app_select[0].threshold_values.find{|tv| tv.name == 'Response Time'}.metric_value
 
   ## Drop the first point value and increment x by 1
   points.shift


### PR DESCRIPTION
In my experience the previous key was selecting the DB metric value.

Thoughts?
