### PR TITLE
Add note to README about activeresource requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Place it inside of the Dashing `Gemfile`:
 gem 'newrelic_api'
 ```
 
+The `newrelic_api` gem also requires `activeresource`, so if you're not using Rails, you will need this in your Gemfile too:
+
+```
+## Gemfile
+gem 'activeresource'
+```
+
 Then `bundle install`
 
 ## Using the New Relic widgets


### PR DESCRIPTION
The `activeresource` gem (required by `newrelic_api`) doesn't get included automatically by bundler, so it must be added to the Gemfile in environments where this gem doesn't happen to be already available.
