### PR TITLE
Set initial values to zero rather than arbitrary non-zero numbers

### DIFF
--- a/jobs/newrelic_error.rb
+++ b/jobs/newrelic_error.rb
@@ -18,7 +18,7 @@ points = []
 
 ## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
 (0..60).each do |a|
-  points << { x: a, y: 0.01 }
+  points << { x: a, y: 0.00 }
 end
 
 ## Grab the last x value

--- a/jobs/newrelic_response.rb
+++ b/jobs/newrelic_response.rb
@@ -18,7 +18,7 @@ points = []
 
 ## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
 (0..60).each do |a|
-  points << { x: a, y: 1 }
+  points << { x: a, y: 0 }
 end
 
 ## Grab the last x value

--- a/jobs/newrelic_rpm.rb
+++ b/jobs/newrelic_rpm.rb
@@ -18,7 +18,7 @@ points = []
 
 ## One hours worth of data, seed 60 empty points (rickshaw acts funny if you don't).
 (0..60).each do |a|
-  points << { x: a, y: 100 }
+  points << { x: a, y: 0 }
 end
 
 ## Grab the last x value


### PR DESCRIPTION
The default non-zero values result in graphs that show a long period
of '1' error or '100' rpm when the real figure is unknown or zero.
Zero seems like a more appropriate default.
