### PR TITLE
Use dashing's history for the chart instead of obliterating on startup

### DIFF
--- a/jobs/newrelic_error.rb
+++ b/jobs/newrelic_error.rb
@@ -13,17 +13,21 @@ NewRelicApi.api_key = key
 app = NewRelicApi::Account.find(:first).applications
 app_select = app.select { |i| i.name =~ /#{app_name}/ }
 
-## Create an array to hold our data points
-points = []
-
-## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
-(0..60).each do |a|
-  points << { x: a, y: 0.01 }
+history = YAML.load(Sinatra::Application.settings.history['newrelic-error'].to_s)
+unless history === false
+  points = []
+  points = history['data']['points'].last(60)
+else
+  ## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
+  ## Create an array to hold our data points
+  points = []
+  (0..59).each do |a|
+    points << { 'x' => a, 'y' => 0.00 }
+  end
 end
 
 ## Grab the last x value
-last_x = points.last[:x]
-
+last_x = points.last['x']
 
 ## Just under a minute works great for New Relic data
 SCHEDULER.every '0.9m', :first_in => 0 do |job|
@@ -36,7 +40,7 @@ SCHEDULER.every '0.9m', :first_in => 0 do |job|
   last_x += 1
 
   ## Push the most recent point value
-  points << { x: last_x, y: current_error  }
+  points << { 'x' => last_x, 'y' => current_error  }
 
   send_event("newrelic-error", { error_rate: current_error, points: points })
 

--- a/jobs/newrelic_response.rb
+++ b/jobs/newrelic_response.rb
@@ -13,17 +13,21 @@ NewRelicApi.api_key = key
 app = NewRelicApi::Account.find(:first).applications
 app_select = app.select { |i| i.name =~ /#{app_name}/ }
 
-## Create an array to hold our data points
-points = []
-
-## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
-(0..60).each do |a|
-  points << { x: a, y: 1 }
+history = YAML.load(Sinatra::Application.settings.history['newrelic-response'].to_s)
+unless history === false
+  points = []
+  points = history['data']['points'].last(60)
+else
+  ## One hours worth of data for, seed 60 empty points (rickshaw acts funny if you don't).
+  ## Create an array to hold our data points
+  points = []
+  (0..59).each do |a|
+    points << { 'x' => a, 'y' => 0.00 }
+  end
 end
 
 ## Grab the last x value
-last_x = points.last[:x]
-
+last_x = points.last['x']
 
 ## Every 1m for this
 SCHEDULER.every '1m', :first_in => 0 do |job|
@@ -36,7 +40,7 @@ SCHEDULER.every '1m', :first_in => 0 do |job|
   last_x += 1
 
   ## Push the most recent point value
-  points << { x: last_x, y: current_response  }
+  points << { 'x' => last_x, 'y' => current_response  }
 
   send_event("newrelic-response", { response: current_response.to_s + ' ms', points: points })
 


### PR DESCRIPTION
Instead of initializing an array of 'zeroed' points on startup, use dashing's stored history if available.
