### PR TITLE
Threshold values are compared as String and not numbers, resulting in incorrect behaviors

### DIFF
--- a/widgets/newrelic/newrelic.coffee
+++ b/widgets/newrelic/newrelic.coffee
@@ -19,8 +19,8 @@ class Dashing.Newrelic extends Dashing.Widget
 
   onData: (data) ->
 
-    @responseGreen = document.getElementById(this.id).getAttribute('data-green')
-    @responseYellow = document.getElementById(this.id).getAttribute('data-yellow')
+    @responseGreen = parseInt(document.getElementById(this.id).getAttribute('data-green'))
+    @responseYellow = parseInt(document.getElementById(this.id).getAttribute('data-yellow'))
 
     val = data.current
     if (


### PR DESCRIPTION
I found that my monitors were going red when the value was below the data-green threshold.

For example val = 100, data-green=500 and data-yellow=1000. This resulted in a red background and not a green one as you would expect.

The issue is that the values for data-green and data-yellow that are returned by

``` javascript

document.getElementById(this.id).getAttribute('data-green')

```

are String and not numbers. When compared then "500" is in fact greater than "1000". I also found that "100" is less than "1000" because the string is shorter, not because the number is less.

Parsing the numbers to ints fixed the issue for me.
